### PR TITLE
Replace `clang-devel` with `llvm-toolset-7-clang-devel`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 Using the upstream manylinux images, with some additions:
 
 - `manylinux2014_x86_64`
-    - `clang-devel`
+    - `llvm-toolset-7-clang-devel`

--- a/manylinux2014_x86_64/Dockerfile
+++ b/manylinux2014_x86_64/Dockerfile
@@ -1,3 +1,5 @@
 FROM quay.io/pypa/manylinux2014_x86_64
 
-RUN yum install -y clang-devel && yum clean all
+ENV LIBCLANG_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64
+
+RUN yum install -y llvm-toolset-7-clang-devel && yum clean all


### PR DESCRIPTION
Turns out, clang-devel is very old...